### PR TITLE
Update nanvix to 4cde8f19 and fix API compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,8 +40,8 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arch"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "cfg-if",
  "config",
@@ -208,8 +208,8 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "cfg-if",
 ]
@@ -222,8 +222,8 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "control-plane-api"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "config",
  "num_enum",
@@ -385,8 +385,8 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "error"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "sysapi",
 ]
@@ -614,8 +614,8 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hwloc"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "anyhow",
  "libc",
@@ -691,20 +691,21 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-common"
-version = "0.8.0"
-source = "git+https://github.com/nanvix/hyperlight?rev=122ba3639e7e18bb0be548408c3646b365f9ef78#122ba3639e7e18bb0be548408c3646b365f9ef78"
+version = "0.12.0"
+source = "git+https://github.com/nanvix/hyperlight?branch=nanvix%2Fv0.12.0#6fa8363f88f0118970ead70d0256a1306bcf8ea3"
 dependencies = [
  "anyhow",
  "flatbuffers",
  "log",
  "spin 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
 [[package]]
 name = "hyperlight-host"
-version = "0.8.0"
-source = "git+https://github.com/nanvix/hyperlight?rev=122ba3639e7e18bb0be548408c3646b365f9ef78#122ba3639e7e18bb0be548408c3646b365f9ef78"
+version = "0.12.0"
+source = "git+https://github.com/nanvix/hyperlight?branch=nanvix%2Fv0.12.0#6fa8363f88f0118970ead70d0256a1306bcf8ea3"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -716,8 +717,8 @@ dependencies = [
  "flatbuffers",
  "goblin",
  "hyperlight-common",
- "kvm-bindings 0.13.0",
- "kvm-ioctls 0.23.0",
+ "kvm-bindings",
+ "kvm-ioctls",
  "lazy_static",
  "libc",
  "log",
@@ -735,10 +736,10 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "uuid",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
  "windows",
- "windows-result 0.3.4",
- "windows-sys 0.60.2",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
  "windows-version",
 ]
 
@@ -767,7 +768,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -925,34 +926,13 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3432d9f609fbede9f624d1dbefcce77985a9322de1d0e6d460ec05502b7fd0"
-dependencies = [
- "vmm-sys-util 0.14.0",
-]
-
-[[package]]
-name = "kvm-bindings"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b3c06ff73c7ce03e780887ec2389d62d2a2a9ddf471ab05c2ff69207cd3f3b4"
 dependencies = [
  "serde",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
  "zerocopy 0.8.27",
-]
-
-[[package]]
-name = "kvm-ioctls"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e00243d27a20feb05cf001ae52ddc79831ac70c020f215ba1153ff9270b650a"
-dependencies = [
- "bitflags 2.10.0",
- "kvm-bindings 0.13.0",
- "libc",
- "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -962,9 +942,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "333f77a20344a448f3f70664918135fddeb804e938f28a99d685bd92926e0b19"
 dependencies = [
  "bitflags 2.10.0",
- "kvm-bindings 0.14.0",
+ "kvm-bindings",
  "libc",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -975,9 +955,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libloading"
@@ -1001,8 +981,8 @@ dependencies = [
 
 [[package]]
 name = "linuxd"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "anyhow",
  "config",
@@ -1038,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru-slab"
@@ -1056,9 +1036,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "metrics"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -1077,32 +1057,32 @@ dependencies = [
 
 [[package]]
 name = "mshv-bindings"
-version = "0.3.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0cb5031f3243a7459b7c13d960d25420980874eebda816db24ce6077e21d43"
+checksum = "66f415da68542aca92b33f55ac3e93031dc30a2941952b99679258f7e0527353"
 dependencies = [
  "libc",
  "num_enum",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
  "zerocopy 0.8.27",
 ]
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.3.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89abe853221fa6f14ad4066affb9abda241a03d65622887d5794e1422d0bd75a"
+checksum = "e52a2a02c4107e08f46ba9dfc4e0f4461dffd44fbeca3e5631b4a047d15376c9"
 dependencies = [
  "libc",
  "mshv-bindings",
  "thiserror 2.0.17",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "nanvix"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "anyhow",
  "config",
@@ -1120,8 +1100,8 @@ dependencies = [
 
 [[package]]
 name = "nanvix-http"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "anyhow",
  "config",
@@ -1144,8 +1124,8 @@ dependencies = [
 
 [[package]]
 name = "nanvix-registry"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1159,8 +1139,8 @@ dependencies = [
 
 [[package]]
 name = "nanvix-sandbox"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1179,8 +1159,8 @@ dependencies = [
 
 [[package]]
 name = "nanvix-sandbox-cache"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "anyhow",
  "config",
@@ -1192,8 +1172,8 @@ dependencies = [
 
 [[package]]
 name = "nanvix-terminal"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "anyhow",
  "libc",
@@ -1422,8 +1402,8 @@ dependencies = [
 
 [[package]]
 name = "profiler"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "cfg-if",
  "syslog",
@@ -1925,8 +1905,8 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assert"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 
 [[package]]
 name = "subtle"
@@ -1967,8 +1947,8 @@ dependencies = [
 
 [[package]]
 name = "sys"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "config",
  "error",
@@ -1977,8 +1957,8 @@ dependencies = [
 
 [[package]]
 name = "sysapi"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "config",
  "static_assert",
@@ -1986,8 +1966,8 @@ dependencies = [
 
 [[package]]
 name = "syscall"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "arch",
  "cfg-if",
@@ -2001,8 +1981,8 @@ dependencies = [
 
 [[package]]
 name = "syscomm"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "config",
  "libc",
@@ -2013,8 +1993,8 @@ dependencies = [
 
 [[package]]
 name = "syslog"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "flexi_logger",
  "log",
@@ -2213,9 +2193,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -2225,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2236,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2263,8 +2243,8 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "type-safe"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 
 [[package]]
 name = "typenum"
@@ -2310,8 +2290,8 @@ dependencies = [
 
 [[package]]
 name = "user-vm-api"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "config",
  "serde",
@@ -2322,8 +2302,8 @@ dependencies = [
 
 [[package]]
 name = "uservm"
-version = "0.10.105"
-source = "git+https://github.com/nanvix/nanvix?rev=fd0b906f2fd014c7fdb4ecbbd83a4171603b251a#fd0b906f2fd014c7fdb4ecbbd83a4171603b251a"
+version = "0.11.24"
+source = "git+https://github.com/nanvix/nanvix?rev=4cde8f1903f54b6cf6117f0ea5061a1c00a68973#4cde8f1903f54b6cf6117f0ea5061a1c00a68973"
 dependencies = [
  "anyhow",
  "arch",
@@ -2332,8 +2312,8 @@ dependencies = [
  "config",
  "control-plane-api",
  "hyperlight-host",
- "kvm-bindings 0.14.0",
- "kvm-ioctls 0.24.0",
+ "kvm-bindings",
+ "kvm-ioctls",
  "libc",
  "profiler",
  "serde",
@@ -2344,7 +2324,7 @@ dependencies = [
  "syslog",
  "tokio",
  "user-vm-api",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2355,9 +2335,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
@@ -2381,16 +2361,6 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
-
-[[package]]
-name = "vmm-sys-util"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
 
 [[package]]
 name = "vmm-sys-util"
@@ -2556,37 +2526,23 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2604,12 +2560,12 @@ dependencies = [
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link 0.2.1",
  "windows-threading",
 ]
 
@@ -2649,12 +2605,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2766,11 +2722,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 description = "A Hyperlight VMM wrapper with out-of-the-box support for running Nanvix microkernel guests"
 
 [dependencies]
-nanvix = { git = "https://github.com/nanvix/nanvix", rev = "fd0b906f2fd014c7fdb4ecbbd83a4171603b251a", features = ["single-process", "hyperlight"] }
+nanvix = { git = "https://github.com/nanvix/nanvix", rev = "4cde8f1903f54b6cf6117f0ea5061a1c00a68973", features = ["single-process", "hyperlight"] }
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 anyhow = "1.0"
-libc = "0.2"
+libc = "0.2.178"
 
 # NAPI bindings (optional)
 napi = { version = "3.5.0", optional = true, features = ["async", "serde-json"] }

--- a/src/bin/hyperlight-nanvix.rs
+++ b/src/bin/hyperlight-nanvix.rs
@@ -20,7 +20,7 @@ async fn setup_registry_command() -> Result<()> {
         println!("Registry already set up at ~/.cache/nanvix-registry/");
     } else {
         // Trigger registry download by requesting key binaries
-        let registry = Registry::new();
+        let registry = Registry::new(None);
         
         if !kernel_cached {
             print!("Downloading kernel.elf... ");
@@ -135,6 +135,7 @@ async fn main() -> Result<()> {
             false,
             DEFAULT_LOG_LEVEL,
             "/tmp/hyperlight-nanvix".to_string(),
+            None,
         );
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -125,7 +125,7 @@ pub struct Runtime {
 
 impl Runtime {
     pub fn new(config: RuntimeConfig) -> Result<Self> {
-        let registry = Registry::new();
+        let registry = Registry::new(None);
         Ok(Self { config, registry })
     }
 


### PR DESCRIPTION
- Update nanvix dependency to latest commit (4cde8f1903f54b6cf6117f0ea5061a1c00a68973)
- Update libc to 0.2.178 for Hyperlight v0.12.0 compatibility
- Fix Registry::new() to accept Option<PathBuf> parameter
- Fix log::init() to accept 4th parameter